### PR TITLE
Update README.md , add option to mvn commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ How to run JCuda code:
 * Call _mvn clean package_ to build project (it will copy all dependencies to _target/lib_ dir)
 	* Users who configure a repository manager like nexus add option _-Dmaven.repo.local=repo_ to the maven cleanPackage command.
 * Call _mvn exec:exec_ to run main class (org.mystic.cuda.JCudaRuntimeTest) with "Hello, JCuda" sample :)
+	* Users who configure a repository manager like nexus add option _-Dmaven.repo.local=repo_ to the maven exec:exec command.
 * If you want to run code directly from your IDE without **Maven** - you could do it via _Run_ command in most of the IDE (Intellij IDEA, Eclipse, Netbeans, etc.) All you need to do - is to add property _-Djava.library.path=target/lib_ (more information is on Stackoverflow - http://stackoverflow.com/q/28333226/2663985)
 * ???
 * Fork! Write your own JCuda code! Run! Report bugs! Support!

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ How to run JCuda code:
     * If you run **JCuda 0.6.0** and higher on **Unix x86_64** platform - everything is ok
     * If you run **JCUda 0.6.0** and higher on **Mac x86_64** - everything is ok
 * Call _mvn clean package_ to build project (it will copy all dependencies to _target/lib_ dir)
+	* Users who configure a repository manager like nexus add option _-Dmaven.repo.local=repo_ to the maven cleanPackage command.
 * Call _mvn exec:exec_ to run main class (org.mystic.cuda.JCudaRuntimeTest) with "Hello, JCuda" sample :)
 * If you want to run code directly from your IDE without **Maven** - you could do it via _Run_ command in most of the IDE (Intellij IDEA, Eclipse, Netbeans, etc.) All you need to do - is to add property _-Djava.library.path=target/lib_ (more information is on Stackoverflow - http://stackoverflow.com/q/28333226/2663985)
 * ???


### PR DESCRIPTION
I had problem with nexus and I couldn't build jCuda. And after Konstantine told me to turn nexus off, I got jCuda build nice and sound. After manipulating maven settings.xml and change manything while I got stuck with nexus, I found that the best way to work with nexus here is to add option -Dmaven.repo.local=repo to both maven commands. It is tested in Ubuntu 14.04 64bit, Maven 3.3.3