### PR TITLE
profile's id in pom.xml should be unique

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -334,7 +334,7 @@
        will work automatically, thanks to auto activation
         -->
         <profile>
-            <id>ppc_64</id>
+            <id>ppc64</id>
             <activation>
                 <os>
                     <family>unix</family>
@@ -411,7 +411,7 @@
        will work automatically, thanks to auto activation
         -->
         <profile>
-            <id>ppc_64</id>
+            <id>ppc64le</id>
             <activation>
                 <os>
                     <family>unix</family>


### PR DESCRIPTION
When I apply this change for  #8, it confirmed openjdk and ibmjdk work well.

```
$ rm -rf ~/.m2/repository/jcuda/ ~/.m2/repository/org/mystic
$ JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-ppc64el mvn install
...
$ find /home/ishizaki/.m2/repository/jcuda/ -name "*.so"
/home/ishizaki/.m2/repository/jcuda/libJCusolver/0.7.0a/libJCusolver-0.7.0a-ppc_64.so
/home/ishizaki/.m2/repository/jcuda/libJCudaRuntime/0.7.0a/libJCudaRuntime-0.7.0a-ppc_64.so
/home/ishizaki/.m2/repository/jcuda/libJCublas/0.7.0a/libJCublas-0.7.0a-ppc_64.so
/home/ishizaki/.m2/repository/jcuda/libJCufft/0.7.0a/libJCufft-0.7.0a-ppc_64.so
/home/ishizaki/.m2/repository/jcuda/libJCurand/0.7.0a/libJCurand-0.7.0a-ppc_64.so
/home/ishizaki/.m2/repository/jcuda/libJCublas2/0.7.0a/libJCublas2-0.7.0a-ppc_64.so
/home/ishizaki/.m2/repository/jcuda/libJCudaDriver/0.7.0a/libJCudaDriver-0.7.0a-ppc_64.so
/home/ishizaki/.m2/repository/jcuda/libJCusparse/0.7.0a/libJCusparse-0.7.0a-ppc_64.so

$ rm -rf ~/.m2/repository/jcuda/ ~/.m2/repository/org/mystic
$ JAVA_HOME=/opt/ibm/ibm-java-ppc64le-80-10 mvn install
...
$ find /home/ishizaki/.m2/repository/jcuda/ -name "*.so"
/home/ishizaki/.m2/repository/jcuda/libJCusolver/0.7.0a/libJCusolver-0.7.0a-ppc_64.so
/home/ishizaki/.m2/repository/jcuda/libJCudaRuntime/0.7.0a/libJCudaRuntime-0.7.0a-ppc_64.so
/home/ishizaki/.m2/repository/jcuda/libJCublas/0.7.0a/libJCublas-0.7.0a-ppc_64.so
/home/ishizaki/.m2/repository/jcuda/libJCufft/0.7.0a/libJCufft-0.7.0a-ppc_64.so
/home/ishizaki/.m2/repository/jcuda/libJCurand/0.7.0a/libJCurand-0.7.0a-ppc_64.so
/home/ishizaki/.m2/repository/jcuda/libJCublas2/0.7.0a/libJCublas2-0.7.0a-ppc_64.so
/home/ishizaki/.m2/repository/jcuda/libJCudaDriver/0.7.0a/libJCudaDriver-0.7.0a-ppc_64.so
/home/ishizaki/.m2/repository/jcuda/libJCusparse/0.7.0a/libJCusparse-0.7.0a-ppc_64.so
```